### PR TITLE
Update RFM69_JeeLib.h for use with AVR128DB28 DIP

### DIFF
--- a/RFM69_JeeLib.h
+++ b/RFM69_JeeLib.h
@@ -29,7 +29,11 @@
 #endif
      
 #ifdef EMONTX4
-  #define SSpin PIN_PB5
+  #ifdef PIN_PB5           //Available on AVR128DB48 (EMONTX4) but not AVR128DB28 DIP
+    #define SSpin PIN_PB5  //EMONTX4 
+  #else
+    #define SSpin PIN_PC3  //AVR128DB28 28-pin DIP for breadboard and prototyping work
+  #endif
   #define MOSIpin PIN_PC0
   #define MISOpin PIN_PC1
   #define SCKpin PIN_PC2


### PR DESCRIPTION
Added a definition for the AVR128DB28 DIP so breadboard/prototyping users can use this library. The user can now use #define EMONTX4 in their sketch and the compiler will use PIN_PC3 for as the chip select pin (SSpin) when it detects that PIN_PB5 is not defined. (The 28-pin part lacks a PIN_PB5). That is the only change needed to transmit JeeLib Classic-compatible packets with the 28-pin DIP using the EMONTX4 SPI definitions.

This could be useful for a JeeLib Classic user getting started with AVRDB on a breadboard like this: https://community.openenergymonitor.org/t/getting-started-with-the-avr-db-on-a-breadboard/20255